### PR TITLE
change urllib to urllib.parse for python3

### DIFF
--- a/src/posts/templatetags/urlify.py
+++ b/src/posts/templatetags/urlify.py
@@ -1,4 +1,4 @@
-from urllib import quote_plus
+from urllib.parse import quote_plus 
 from django import template
 
 register = template.Library()

--- a/src/posts/views.py
+++ b/src/posts/views.py
@@ -1,4 +1,4 @@
-from urllib import quote_plus
+from urllib.parse import quote_plus # python3
 
 from django.contrib import messages
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger


### PR DESCRIPTION
fix urllib import error in python3
